### PR TITLE
Handle spaces in URLs using decodeURI() function

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -46,6 +46,8 @@ function isValidRelativeLink(link) {
 }
 
 function getPathWithoutQueryOrHash(url) {
+  // Use decodeURI to handle spaces in the URL
+  url = decodeURI(url);
   const indexQuery = url.indexOf("?");
   const indexHash = url.indexOf("#");
 


### PR DESCRIPTION
This allows paths with encoded spaces (%20) to be converted back into real space characters, allowing them to be resolved. This allows consuming Markdown files from projects like [obsidian-export](https://github.com/zoni/obsidian-export) which use this strategy for filenames with spaces in them.

Truth be told, I haven't done extensive testing on whether this causes unexpected results, but it does appear to fix the immediate issue of filenames with spaces being untouched.