### PR TITLE
Use Astro's sluggifier for wider coverage incl. special chars

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "debug": "^4.3.4",
+    "github-slugger": "^2.0.0",
     "gray-matter": "^4.0.3",
     "unist-util-visit": "^4.1.2"
   },

--- a/src/fixtures/test (non-alpha).md
+++ b/src/fixtures/test (non-alpha).md
@@ -1,0 +1,1 @@
+# Test File with non alphanumeric characters in name

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -109,4 +109,20 @@ test("astroRehypeRelativeMarkdownLinks", async (t) => {
       assert.equal(actual, expected);
     },
   );
+
+  await t.test(
+    "should transform paths with non alphanumeric characters",
+    async () => {
+      const input = '<a href="./fixtures/test%20(non-alpha).md">foo</a>';
+      const { value: actual } = await rehype()
+        .use(testSetupRehype)
+        .use(astroRehypeRelativeMarkdownLinks, { contentPath: "src" })
+        .process(input);
+
+      const expected =
+        '<html><head></head><body><a href="/fixtures/test-non-alpha">foo</a></body></html>';
+
+      assert.equal(actual, expected);
+    },
+  );
 });

--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -1,10 +1,8 @@
 import path from "path";
+import { slug as githubSlug } from "github-slugger";
 
 const pathSeparator = path.sep;
 const validMarkdownExtensions = [".md", ".mdx"];
-
-// value to be used when normalising the content paths that contain spaces (used in join)
-const ASTRO_PATH_JOIN_DELIMITER = "-";
 
 /** @type {import('./utils').IsCurrentDirectoryFn} */
 function isCurrentDirectory(fpath) {
@@ -84,9 +82,18 @@ export const normaliseAstroOutputPath = (initialPath, options = {}) => {
     return;
   }
 
-  const normalisedPath = initialPath
-    .toLowerCase()
-    .replace(/ /g, ASTRO_PATH_JOIN_DELIMITER);
+  const [pathWithoutQueryAndFragment, queryStringAndFragment] =
+    splitPathFromQueryAndFragment(initialPath);
+
+  const pathSegments = pathWithoutQueryAndFragment.split(pathSeparator);
+
+  let normalisedPath = pathSegments
+    .map((segment) => githubSlug(segment).toLowerCase())
+    .join("/");
+
+  if (queryStringAndFragment) {
+    normalisedPath += queryStringAndFragment;
+  }
 
   if (!options.basePath) {
     return normalisedPath;

--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -88,7 +88,7 @@ export const normaliseAstroOutputPath = (initialPath, options = {}) => {
   const pathSegments = pathWithoutQueryAndFragment.split(pathSeparator);
 
   let normalisedPath = pathSegments
-    .map((segment) => githubSlug(segment).toLowerCase())
+    .map((segment) => githubSlug(segment))
     .join("/");
 
   if (queryStringAndFragment) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -116,6 +116,7 @@ __metadata:
   resolution: "astro-rehype-relative-markdown-links@workspace:."
   dependencies:
     debug: "npm:^4.3.4"
+    github-slugger: "npm:^2.0.0"
     gray-matter: "npm:^4.0.3"
     prettier: "npm:^4.0.0-alpha.8"
     rehype: "npm:^13.0.1"
@@ -267,6 +268,13 @@ __metadata:
   dependencies:
     find-up-json: "npm:^2.0.1"
   checksum: 10c0/45792713e235865d6c63d9c6421ec153b2c0da6fe1e12c70d6088c628fa4c6d77a21c7780c003c62f34e77b467cc9f53ec10ebe2e4a5804173ef938130197d86
+  languageName: node
+  linkType: hard
+
+"github-slugger@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "github-slugger@npm:2.0.0"
+  checksum: 10c0/21b912b6b1e48f1e5a50b2292b48df0ff6abeeb0691b161b3d93d84f4ae6b1acd6ae23702e914af7ea5d441c096453cf0f621b72d57893946618d21dd1a1c486
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Updates sluggifier for broader coverage, addressing cases with non-alphanumeric characters. Refs: https://github.com/withastro/astro/blob/ad57a02c330b544770ab853fe0521eb784421016/packages/astro/src/content/utils.ts#L224

It handles cases like `./Zen%20to%20Done%20(ZTD).md` where Astro generates `zen-to-done-ztd` route, but the extension transforms it to `zen-to-done-(ztd)`, causing 404 errors due to route mismatch.