### PR TITLE
fix(changelog): split workflow into two jobs

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -23,6 +23,14 @@ jobs:
       - run: yarn npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  update_changelog:
+    needs: publish
+    runs-on: ubuntu-latest
+    environment:
+      name: npm-publish
+    steps:
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
       - uses: actions/cache@v4
         with:


### PR DESCRIPTION
instead of relying on one job to do the publishing and changelog update, this pr splits it into two