### PR TITLE
perf: cache frontmatter

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "pre-release": "yarn run changelog && yarn run prettier && yarn run generate-docs",
     "generate-docs": "typedoc --readme none --gitRevision main --plugin typedoc-plugin-markdown src",
     "prettier": "prettier ./src/** -w",
-    "test": "node --loader=esmock --test",
+    "test": "MATTER_CACHE_DISABLE=true node --loader=esmock --test",
     "type-check": "tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "pre-release": "yarn run changelog && yarn run prettier && yarn run generate-docs",
     "generate-docs": "typedoc --readme none --gitRevision main --plugin typedoc-plugin-markdown src",
     "prettier": "prettier ./src/** -w",
-    "test": "MATTER_CACHE_DISABLE=true node --loader=esmock --test",
+    "test": "ARRML_MATTER_CACHE_DISABLE=true node --loader=esmock --test",
     "type-check": "tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,7 +1,5 @@
 import { visit } from "unist-util-visit";
 import * as path from "path";
-import * as fs from "fs";
-import { default as matter } from "gray-matter";
 import { default as debugFn } from "debug";
 import {
   replaceExt,
@@ -15,6 +13,7 @@ import {
   URL_PATH_SEPARATOR,
   FILE_PATH_SEPARATOR,
   shouldProcessFile,
+  getMatter,
 } from "./utils.mjs";
 import { validateOptions } from "./options.mjs";
 
@@ -63,9 +62,7 @@ function astroRehypeRelativeMarkdownLinks(opts = {}) {
       }
 
       // read gray matter from href file
-      const urlFileContent = fs.readFileSync(urlFilePath);
-      const { data: frontmatter } = matter(urlFileContent);
-      const frontmatterSlug = frontmatter.slug;
+      const { slug: frontmatterSlug } = getMatter(urlFilePath);
       const contentDir = path.resolve(options.contentPath);
       const collectionPathMode = options.collectionPathMode;
       const trailingSlashMode = options.trailingSlash;

--- a/src/utils.d.ts
+++ b/src/utils.d.ts
@@ -23,3 +23,5 @@ export type NormaliseAstroOutputPath = (
 export type Slash = (path: string, sep: string) => string;
 export type NormalizePath = (path: string) => string;
 export type ShouldProcessFile = (path: string) => boolean;
+export type MatterData = { slug?: string };
+export type GetMatter = (path: string) => MatterData;

--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -1,9 +1,10 @@
 import path from "path";
-import { statSync } from "fs";
+import { readFileSync, statSync } from "fs";
 import { slug as githubSlug } from "github-slugger";
 import { z } from "zod";
 import { asError } from "catch-unknown";
 import isAbsoluteUrl from "is-absolute-url";
+import matter from "gray-matter";
 
 const validMarkdownExtensions = [".md", ".mdx"];
 const isWindows =
@@ -166,4 +167,18 @@ export function shouldProcessFile(npath) {
   // Astro excludes files that include underscore in any segment of the path under contentDIr
   // see https://github.com/withastro/astro/blob/0fec72b35cccf80b66a85664877ca9dcc94114aa/packages/astro/src/content/utils.ts#L253
   return !npath.split(path.sep).some((p) => p && p.startsWith("_"));
+}
+
+/** @type {Record<string, import('./utils.d.ts').MatterData>} */
+const matterCache = {};
+/** @type {import('./utils.d.ts').GetMatter} */
+export function getMatter(npath) {
+  const readMatter = () => {
+    const content = readFileSync(npath);
+    const { data: frontmatter } = matter(content);
+    matterCache[npath] = frontmatter;
+    return frontmatter;
+  };
+
+  return matterCache[npath] || readMatter();
 }

--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -171,12 +171,15 @@ export function shouldProcessFile(npath) {
 
 /** @type {Record<string, import('./utils.d.ts').MatterData>} */
 const matterCache = {};
+const matterCacheEnabled = process.env.MATTER_CACHE_DISABLE !== "true";
 /** @type {import('./utils.d.ts').GetMatter} */
 export function getMatter(npath) {
   const readMatter = () => {
     const content = readFileSync(npath);
     const { data: frontmatter } = matter(content);
-    matterCache[npath] = frontmatter;
+    if (matterCacheEnabled) {
+      matterCache[npath] = frontmatter;
+    }
     return frontmatter;
   };
 

--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -171,7 +171,7 @@ export function shouldProcessFile(npath) {
 
 /** @type {Record<string, import('./utils.d.ts').MatterData>} */
 const matterCache = {};
-const matterCacheEnabled = process.env.MATTER_CACHE_DISABLE !== "true";
+const matterCacheEnabled = process.env.ARRML_MATTER_CACHE_DISABLE !== "true";
 /** @type {import('./utils.d.ts').GetMatter} */
 export function getMatter(npath) {
   const readMatter = () => {


### PR DESCRIPTION
**IMPORTANT** - This PR contains the fixes in #55 so should be merged after it.

Caches the frontmatter data per file to avoid reading the file every time a link references it.

Very primitive/raw perf analysis at <https://stackblitz.com/edit/stackblitz-starters-7np4gm>.

1. Navigate to <https://stackblitz.com/edit/stackblitz-starters-7np4gm>
2. In terminal, run `node ./index.js`

Analysis only considers execution time, does not look at memory consumption, etc. but this should yield some memory consumption benefit in most situations as well.

```bash
❯ node ./index.js
cached x 65,687,202 ops/sec ±7.16% (64 runs sampled)
notCached x 8,121 ops/sec ±5.35% (70 runs sampled)
Fastest is cached
```