### PR TITLE
fix: do not transform links outside of a content collection directory

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -109,6 +109,13 @@ function astroRehypeRelativeMarkdownLinks(opts = {}) {
       const collectionName = path
         .dirname(relativeToContentPath)
         .split(FILE_PATH_SEPARATOR)[0];
+      // if linked file is outside of a collection directory
+      if (
+        collectionName === ".." ||
+        (collectionPathMode !== "root" && collectionName === ".")
+      ) {
+        return;
+      }
       const collectionPathSegment =
         collectionPathMode === "root" ? PATH_SEGMENT_EMPTY : collectionName;
       // determine the path of the target file relative to the collection


### PR DESCRIPTION
**IMPORTANT** - This PR contains the fixes in #55 so should be merged after it.

Resolves #57 