### PR TITLE
Update GH Actions - Align docs to releases + chores

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -36,7 +36,11 @@ jobs:
         run: yarn npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: "Trigger update-changelog.yml workflow"
+      - name: "Update Change Log (trigger update-changelog.yml workflow)"
         run: gh workflow run update-changelog.yml --ref main
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: "Generate Docs (trigger update-generated-docs.yml workflow)"
+        run: gh workflow run update-generated-docs.yml --ref main
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -28,6 +28,8 @@ jobs:
           node-version: "20.x"
           registry-url: "https://registry.npmjs.org"
           cache: "yarn"
+      - name: Delete non-packaged files # yarn has problems when it comes to packaging, behaving differently from npm
+        run: rm -rf docs
       - name: Install Dependencies
         run: yarn --immutable
       - name: Publish

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,8 +1,6 @@
 name: Update Changelog
 on:
   workflow_dispatch:
-    branches:
-      - main
 
 permissions:
   contents: write

--- a/.github/workflows/update-generated-docs.yml
+++ b/.github/workflows/update-generated-docs.yml
@@ -1,8 +1,5 @@
 name: Update Generated Docs (typedoc)
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 permissions:

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "src/options.mjs",
     "src/**/*.d.ts",
     "README.md",
-    "docs/**/*.md"
+    "CHANGELOG.md"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
I realised there's a disconnect between the docs generated in the repo and the version of the plugin published to npm. Specifically, the docs in the repo will be ahead of the docs on npm due to the docs being generated on pushes to main. This PR changes the docs to only be generated/updated after a publish is succssful.

Other things:
* Remove docs before publishing (yarn packs docs/README.md no matter what)
* Remove branch config in workflow_dispatch in `.github/workflows/update-changelog.yml`
* Improve action steps naming
* Remove docs from being included in npm package